### PR TITLE
Use attach list

### DIFF
--- a/R/prep.R
+++ b/R/prep.R
@@ -261,19 +261,23 @@ getCallingLineAndFile <- function(frameId = 0, skipCalls = 0) {
   options(continue = "<##v\\s\\c>\n")
   options(browserNLdisabled = TRUE)
 
-  require(pryr, quietly = TRUE, warn.conflicts = FALSE)
+  suppressPackageStartupMessages(loadNamespace("pryr"))
+
+  attachList <- list()
 
   if (overwritePrint) {
-    .GlobalEnv$print <- .vsc.print
+    attachList$print <- .vsc.print
   }
 
   if (overwriteCat) {
-    .GlobalEnv$cat <- .vsc.cat
+    attachList$cat <- .vsc.cat
   }
 
   if (overwriteSource) {
-    .GlobalEnv$source <- .vsc.debugSource
+    attachList$source <- .vsc.debugSource
   }
+
+  attach(attachList, name = "tools:vscDebugger", warn.conflicts = FALSE)
 
   .packageEnv$isEvaluating <- FALSE
 


### PR DESCRIPTION
Close #8 

* `require(pryr, ...)` is replaced with `loadNamespace("pryr")` as `require` tries attach the package and does not stop if not exists while `loadNamespace` only loads the package. All uses of `pryr` in the package is `pryr::` or `pryr:::` so there's no need to attach.
* An `attachList` is used to attach to search path so that the overwritten functions are not directly visible in the global environment.