### PR TITLE
Fix handling of evalRequests with more than 1 expression

### DIFF
--- a/R/prep.R
+++ b/R/prep.R
@@ -60,8 +60,12 @@
   } else{
     # eval
     value <- tryCatch({
-      cl <- call('withVisible', parse(text=expr)[[1]])
-      valueAndVisible <- eval(cl, envir=env)
+      b <- parse(text=expr)
+      valueAndVisible <- list(value='', visible=FALSE)
+      for(exp in b){
+        cl <- call('withVisible', exp)
+        valueAndVisible <- eval(cl, envir=env)
+      }
       if(valueAndVisible$visible){
         value <- valueAndVisible$value
       } else{


### PR DESCRIPTION
Quick fix to handle evalRequests with more than 1 expression  (e.g. "a<-1; b<-2") or none (pressing enter with an empty input line).