### PR TITLE
Modify vsc cat

### DIFF
--- a/R/prep.R
+++ b/R/prep.R
@@ -121,7 +121,7 @@ isPackageFrame <- function(env = parent.frame()) {
   # env <- sys.frame(-1)
   # ret <- capture.output(base::print(...), envir=env)
 
-  if (.packageEnv$isEvaluating) {
+  if (.packageEnv$isEvaluating || !identical(list(...)$file, "")) {
     # return(base::cat(...))
     return(base::cat(...))
   }


### PR DESCRIPTION
Passes calls to `.vsc.cat` that specify a file to base::cat.
(Partly) fixes https://github.com/ManuelHentschel/vscDebugger/issues/11
