### PR TITLE
Use session environment to store debug session globals

### DIFF
--- a/R/aaaGlobals.R
+++ b/R/aaaGlobals.R
@@ -1,2 +1,0 @@
-# create environment for global data used by package functions
-.packageEnv <- new.env()

--- a/R/breakpointManagement.R
+++ b/R/breakpointManagement.R
@@ -30,12 +30,9 @@
 # }
 
 
-.packageEnv$breakpoints <- list()
-
-
 #' @export
 .vsc.setStoredBreakpoints <- function() {
-  for (sbp in .packageEnv$breakpoints) {
+  for (sbp in session$breakpoints) {
     sbp$bps <- .vsc.setBreakpoints(sbp$file, sbp$breakpoints, includePackages = sbp$includePackages)
   }
 }
@@ -55,13 +52,13 @@
 
 #' @export
 .vsc.getAllBreakpoints <- function() {
-  return(.packageEnv$breakpoints)
+  return(session$breakpoints)
 }
 
 #' @export
 .vsc.getBreakpoints <- function(file) {
   file <- normalizePath(file)
-  allBps <- .packageEnv$breakpoints
+  allBps <- session$breakpoints
   matchingBps <- allBps[which(lapply(allBps, function(sbp) sbp$file) == file)]
   if (length(matchingBps) > 0) {
     sbp <- mergeSrcBreakpoints(matchingBps)
@@ -123,24 +120,24 @@
   sbp$breakpoints[[1]] <- bp
 
   addSrcBreakpoint(sbp)
-  .packageEnv$breakpoints <- mergeSrcBreakpoints(.packageEnv$breakpoints)
+  session$breakpoints <- mergeSrcBreakpoints(session$breakpoints)
 }
 
 
 #' @export
 .vsc.clearAllBreakpoints <- function() {
-  .packageEnv$breakpoints <- list()
+  session$breakpoints <- list()
 }
 
 #' @export
 .vsc.clearBreakpointsByFile <- function(file = '') {
   file <- normalizePath(file)
-  whichBreakpoints <- which(lapply(.packageEnv$breakpoints, function(bp) bp$file) == file)
-  .packageEnv$breakpoints[whichBreakpoints] <- NULL
+  whichBreakpoints <- which(lapply(session$breakpoints, function(bp) bp$file) == file)
+  session$breakpoints[whichBreakpoints] <- NULL
 }
 
 addSrcBreakpoints <- function(sbps = list()) {
-  .packageEnv$breakpoints <- c(.packageEnv$breakpoints, sbps)
+  session$breakpoints <- c(session$breakpoints, sbps)
 }
 
 addSrcBreakpoint <- function(sbp = NULL) {

--- a/R/customVarInfo.R
+++ b/R/customVarInfo.R
@@ -24,12 +24,12 @@
 
 #' @export
 .vsc.resetVarInfo <- function() {
-  .packageEnv$varInfo <- defaultVarInfo
+  session$varInfo <- defaultVarInfo
 }
 
 #' @export
 .vsc.clearVarInfo <- function() {
-  .packageEnv$varInfo <- list()
+  session$varInfo <- list()
 }
 
 #' @export
@@ -48,7 +48,7 @@
 ) {
   if (position < 0) {
     # negative positions count from the end, -1 = last position
-    position <- length(.packageEnv$varInfo) + 1 + position
+    position <- length(session$varInfo) + 1 + position
   } else if (position > 0) {
     position <- position - 1
   }
@@ -67,23 +67,23 @@
   varInfo$longType <- longType
   varInfo$includeAttributes <- includeAttribute
 
-  .packageEnv$varInfo <- append(.packageEnv$varInfo, varInfo, position)
+  session$varInfo <- append(session$varInfo, varInfo, position)
 }
 
 #' @export
 .vsc.removeVarInfo <- function(position = 1) {
   if (position < 0) {
-    position <- length(.packageEnv$varInfo) + 1 + position
+    position <- length(session$varInfo) + 1 + position
   }
-  .packageEnv$varInfo[position] <- NULL
+  session$varInfo[position] <- NULL
 }
 
 #' @export
 .vsc.listVarInfo <- function(position = NULL) {
   if (is.null(position)) {
-    position <- seq2(.packageEnv$varInfo)
+    position <- seq2(session$varInfo)
   }
-  return(.packageEnv$varInfo[position])
+  return(session$varInfo[position])
 }
 
 .vsc.checkVarInfo <- function(varInfo, testCase = NULL) {

--- a/R/debugSource.R
+++ b/R/debugSource.R
@@ -13,7 +13,7 @@
   file <- normalizePath(file)
   body <- parse(file, encoding = encoding, keep.source = TRUE)
 
-  # apply breakpoints stored in .packageEnv$breakpoints
+  # apply breakpoints stored in session$breakpoints
   if (applyInternalBreakpoints) {
     bps <- .vsc.getBreakpoints(file)
     lines <- .vsc.getBreakpointLines(file)
@@ -33,8 +33,8 @@
   body <- mySetBreakpoints(body, ats)
 
   # store debugState
-  tmpDebugGlobal <- .packageEnv$debugGlobal
-  .packageEnv$debugGlobal <- FALSE
+  tmpDebugGlobal <- session$debugGlobal
+  session$debugGlobal <- FALSE
 
   # actually run the code:
   enclos <- baseenv()
@@ -43,7 +43,7 @@
 
 
   # restore debugState
-  .packageEnv$debugGlobal <- tmpDebugGlobal
+  session$debugGlobal <- tmpDebugGlobal
 }
 
 

--- a/R/global.R
+++ b/R/global.R
@@ -11,3 +11,8 @@ session <- local({
   debugGlobal <- FALSE
   environment()
 })
+
+.onLoad <- function(...) {
+  options(error = traceback)
+  session$varInfo <- defaultVarInfo
+}

--- a/R/global.R
+++ b/R/global.R
@@ -1,0 +1,13 @@
+# create environment for global data used by package functions
+session <- local({
+  varLists <- list()
+  varListArgs <- list()
+  varListPersistent <- list()
+  isEvaluating <- FALSE
+  frameIdsR <- list()
+  frameIdsVsc <- list()
+  breakpoints <- list()
+  varInfo <- NULL
+  debugGlobal <- FALSE
+  environment()
+})

--- a/R/prep.R
+++ b/R/prep.R
@@ -1,11 +1,6 @@
 ########################################################################
 # Prep
 
-.onLoad <- function(...) {
-  options(error = traceback)
-  session$varInfo <- defaultVarInfo
-}
-
 #' Evaluate an expression and send result to vsc
 #'
 #' Evaluates an expression in a given frameId and sends the result to vsc

--- a/R/prep.R
+++ b/R/prep.R
@@ -1,19 +1,9 @@
 ########################################################################
 # Prep
 
-
-.packageEnv$varLists <- list()
-.packageEnv$varListArgs <- list()
-.packageEnv$varListPersistent <- list()
-.packageEnv$isEvaluating <- FALSE
-.packageEnv$frameIdsR <- list()
-.packageEnv$frameIdsVsc <- list()
-.packageEnv$varInfo <- defaultVarInfo
-.packageEnv$debugGlobal <- FALSE
-
-
 .onLoad <- function(...) {
   options(error = traceback)
+  session$varInfo <- defaultVarInfo
 }
 
 #' Evaluate an expression and send result to vsc
@@ -27,7 +17,7 @@
 #' @param assignToAns Whether to assign the result of the evaluation to .GlobalEnv$.ans
 .vsc.evalInFrame <- function(expr, frameId, silent = TRUE, id = 0, assignToAns = TRUE) {
   # evaluate calls that were made from top level cmd line in the .GlobalEnv
-  if (.packageEnv$debugGlobal && calledFromGlobal()) {
+  if (session$debugGlobal && calledFromGlobal()) {
     env <- .GlobalEnv
   } else {
     frameIdR <- convertFrameId(vsc = frameId)
@@ -35,13 +25,13 @@
   }
 
   # prepare settings
-  tmpDebugGlobal <- .packageEnv$debugGlobal
-  .packageEnv$debugGlobal <- FALSE
+  tmpDebugGlobal <- session$debugGlobal
+  session$debugGlobal <- FALSE
 
   if(silent){
     # prepare settings
     options(error=traceback)
-    .packageEnv$isEvaluating <- TRUE
+    session$isEvaluating <- TRUE
     ts <- tracingState(FALSE)
 
     # eval
@@ -56,7 +46,7 @@
 
     # reset settings
     tracingState(ts)
-    .packageEnv$isEvaluating <- FALSE
+    session$isEvaluating <- FALSE
     options(error = .vsc.onError)
   } else{
     # eval
@@ -80,7 +70,7 @@
   }
 
   # reset settings
-  .packageEnv$debugGlobal <- tmpDebugGlobal
+  session$debugGlobal <- tmpDebugGlobal
 
 
   # prepare and send result
@@ -131,7 +121,7 @@ isPackageFrame <- function(env = parent.frame()) {
   # env <- sys.frame(-1)
   # ret <- capture.output(base::print(...), envir=env)
 
-  if (.packageEnv$isEvaluating || !identical(list(...)$file, "")) {
+  if (session$isEvaluating || !identical(list(...)$file, "")) {
     # return(base::cat(...))
     return(base::cat(...))
   }
@@ -158,7 +148,7 @@ isPackageFrame <- function(env = parent.frame()) {
   # env <- sys.frame(-1)
   # ret <- capture.output(base::print(...), envir=env)
 
-  if (.packageEnv$isEvaluating) {
+  if (session$isEvaluating) {
     return(base::print(x, ...))
   }
   ret <- capture.output(base::print(x, ...))
@@ -313,7 +303,7 @@ getCallingLineAndFile <- function(frameId = 0, skipCalls = 0) {
 #' @param overWriteCat Whether to overwrite \code{base::cat} with a version that sends output to vsc
 .vsc.prepGlobalEnv <- function(overwritePrint = TRUE, overwriteCat = TRUE, overwriteSource = TRUE, findMain = TRUE, mainFunction = 'main', debugGlobal = FALSE) {
 
-  .packageEnv$debugGlobal <- debugGlobal
+  session$debugGlobal <- debugGlobal
 
   options(prompt = "<#v\\s\\c>\n")
   options(continue = "<##v\\s\\c>\n")
@@ -337,7 +327,7 @@ getCallingLineAndFile <- function(frameId = 0, skipCalls = 0) {
 
   attach(attachList, name = "tools:vscDebugger", warn.conflicts = FALSE)
 
-  .packageEnv$isEvaluating <- FALSE
+  session$isEvaluating <- FALSE
 
   options(error = .vsc.onError)
   .vsc.sendToVsc('go')
@@ -374,7 +364,7 @@ getCallingLineAndFile <- function(frameId = 0, skipCalls = 0) {
 #' @export
 #' @return Boolean indicating whether an expression is being evaluated
 .vsc.isEvaluating <- function() {
-  return(.packageEnv$isEvaluating)
+  return(session$isEvaluating)
 }
 
 
@@ -385,7 +375,7 @@ getCallingLineAndFile <- function(frameId = 0, skipCalls = 0) {
 #' @export
 #' @return Boolean indicating whether R should stop on breakpoints
 .vsc.stopOnBreakpoint <- function() {
-  return(!.packageEnv$isEvaluating)
+  return(!session$isEvaluating)
 }
 
 #' Same as base::cat

--- a/R/stack.R
+++ b/R/stack.R
@@ -62,7 +62,7 @@
     lastenv <- globalenv()
   }
 
-  if (forceDummyStack || .packageEnv$debugGlobal && calledFromGlobal()) {
+  if (forceDummyStack || session$debugGlobal && calledFromGlobal()) {
     stack <- .vsc.getDummyStack(dummyFile = dummyFile, lastenv = lastenv)
   } else {
     stack <- .vsc.buildStack(topFrame = topFrame, isError = isError, skipFromBottom = 0, lastenv = lastenv)
@@ -99,19 +99,19 @@
   )
   stack <- list(
     frames = frames,
-    varLists = .packageEnv$varLists
+    varLists = session$varLists
   )
-  .packageEnv$frameIdsR <- frameIdsR
-  .packageEnv$frameIdsVsc <- frameIdsVsc
+  session$frameIdsR <- frameIdsR
+  session$frameIdsVsc <- frameIdsVsc
   return(stack)
 }
 
 
 clearVarLists <- function(deleteAll = FALSE){
-  for(i in seq2(.packageEnv$varLists)){
-    if(deleteAll || !.packageEnv$varListPersistent[[i]]){
-      .packageEnv$varLists[[i]] <- list()
-      .packageEnv$varListArgs[[i]] <- list()
+  for(i in seq2(session$varLists)){
+    if(deleteAll || !session$varListPersistent[[i]]){
+      session$varLists[[i]] <- list()
+      session$varListArgs[[i]] <- list()
     }
   }
 }
@@ -142,10 +142,10 @@ clearVarLists <- function(deleteAll = FALSE){
   )
   stack <- list(
     frames = frames,
-    varLists = .packageEnv$varLists
+    varLists = session$varLists
   )
-  .packageEnv$frameIdsR <- frameIdsR
-  .packageEnv$frameIdsVsc <- frameIdsVsc
+  session$frameIdsR <- frameIdsR
+  session$frameIdsVsc <- frameIdsVsc
   return(stack)
 }
 
@@ -200,16 +200,16 @@ convertFrameId <- function(vsc = NULL, R = NULL) {
   if (is.null(vsc) && is.null(R)) {
     return(NULL)
   } else if (is.null(vsc)) {
-    ind <- which(R == .packageEnv$frameIdsR)
+    ind <- which(R == session$frameIdsR)
     if (length(ind) > 0) {
-      return(.packageEnv$frameIdsVsc[ind])
+      return(session$frameIdsVsc[ind])
     } else {
       return(NULL)
     }
   } else {
-    ind <- which(vsc == .packageEnv$frameIdsVsc)
+    ind <- which(vsc == session$frameIdsVsc)
     if (length(ind) > 0) {
-      return(.packageEnv$frameIdsR[ind])
+      return(session$frameIdsR[ind])
     } else {
       return(NULL)
     }
@@ -389,10 +389,10 @@ getScopeEnvs <- function(firstenv = parent.frame(), lastenv = .GlobalEnv) {
 #' 
 getVarRefForVarListArgs <- function(varListArgs = NULL, evalCall = FALSE, varRef = NULL, persistent=FALSE) {
   if (is.null(varRef)) {
-    varRef <- length(.packageEnv$varListArgs) + 1
+    varRef <- length(session$varListArgs) + 1
   }
-  .packageEnv$varListArgs[[varRef]] <- varListArgs
-  .packageEnv$varListPersistent[[varRef]] <- persistent
+  session$varListArgs[[varRef]] <- varListArgs
+  session$varListPersistent[[varRef]] <- persistent
   if (evalCall) {
     # use arglist instead of call/eval/do.call to avoid evaluating the content of variables that contain expressions
     v <- varListArgs$v
@@ -406,9 +406,9 @@ getVarRefForVarListArgs <- function(varListArgs = NULL, evalCall = FALSE, varRef
       isReady = TRUE,
       variables = variables
     )
-    .packageEnv$varLists[[varRef]] <- varList
+    session$varLists[[varRef]] <- varList
   } else {
-    .packageEnv$varLists[[varRef]] <- list(
+    session$varLists[[varRef]] <- list(
       reference = 0,
       isReady = FALSE,
       variables = list()
@@ -419,7 +419,7 @@ getVarRefForVarListArgs <- function(varListArgs = NULL, evalCall = FALSE, varRef
 
 #' Get the variable corresponding to a variablesReference
 #' 
-#' Is basically is a wrapper for \code{.packageEnv$varLists[[varRef]]}.
+#' Is basically is a wrapper for \code{session$varLists[[varRef]]}.
 #' If necessary evaluates the call for a given varRef and returns the result.
 #' 
 #' @param varRef The variablesReference as returned by \code{getVarRefForVarListArgs} or \code{getVarRefForVar}
@@ -427,12 +427,12 @@ getVarRefForVarListArgs <- function(varListArgs = NULL, evalCall = FALSE, varRef
 getVarListsEntry <- function(varRef) {
   # 
   # to avoid excessive nested calls, the varList is only computed once requested
-  # before the varList is requested, only the arguments for getVarList() that will return it is stored in .packageEnv$varListArgs
+  # before the varList is requested, only the arguments for getVarList() that will return it is stored in session$varListArgs
 
 
   # retrieve varList (if exists)
-  if(varRef <= length(.packageEnv$varLists)){
-    varList <- .packageEnv$varLists[[varRef]]
+  if(varRef <= length(session$varLists)){
+    varList <- session$varLists[[varRef]]
     returnDummy <- is.null(varList$isReady)
   } else{
     returnDummy <- TRUE
@@ -449,7 +449,7 @@ getVarListsEntry <- function(varRef) {
 
   # compute varList if necessary
   if (!varList$isReady) {
-    varListArgs <- .packageEnv$varListArgs[[varRef]]
+    varListArgs <- session$varListArgs[[varRef]]
     v <- varListArgs$v
     depth <- varListArgs$depth
     maxVars <- varListArgs$maxVars
@@ -462,7 +462,7 @@ getVarListsEntry <- function(varRef) {
       isReady = TRUE,
       variables = variables
     )
-    .packageEnv$varLists[[varRef]] <- varList
+    session$varLists[[varRef]] <- varList
   }
 
   return(varList)
@@ -673,7 +673,7 @@ getVarRefForVar <- function(valueR, depth = 10, maxVars = 1000, includeAttribute
 
 
 getCustomInfo <- function(v, info, default = NULL, onError = NULL) {
-  # checks the entries in .packageEnv$varInfo (specified in customVarinfo.R) for a matching entry
+  # checks the entries in session$varInfo (specified in customVarinfo.R) for a matching entry
   # returns the requested info if available
   # info can be a string from the list:
   #     childVars
@@ -687,7 +687,7 @@ getCustomInfo <- function(v, info, default = NULL, onError = NULL) {
   ret <- default
   try({
     # loop through varInfos
-    for (varInfo in .packageEnv$varInfo) {
+    for (varInfo in session$varInfo) {
       # check if varInfo provides the required info
       if (!is.null(varInfo[[info]])) {
         # check if varInfo applies to v

--- a/man/getVarListsEntry.Rd
+++ b/man/getVarListsEntry.Rd
@@ -13,6 +13,6 @@ getVarListsEntry(varRef)
 A list of variables corresponding to the varRef
 }
 \description{
-Is basically is a wrapper for \code{.packageEnv$varLists[[varRef]]}.
+Is basically is a wrapper for \code{session$varLists[[varRef]]}.
 If necessary evaluates the call for a given varRef and returns the result.
 }


### PR DESCRIPTION
Close #25 

This PR renames `.packageEnv` to `session` to store debug session global variables, which I believe is easier and cleaner to work with.

The `session` object is defined in `global.R`, and `.onLoad` is moved into the file too to indicate everything that happens globally. All access to `session` in other places should be inside a function.