### PR TITLE
Add skipCalls to .vsc.print and .vsc.cat

### DIFF
--- a/R/prep.R
+++ b/R/prep.R
@@ -129,8 +129,9 @@ isPackageFrame <- function(env = parent.frame()) {
 #' Captures the output of \code{cat(...)} and sends it to vsc together with information about the sourcefile and line
 #' @export
 #' @param ... Arguments passed to base::cat()
+#' @param skipCalls The number of calls to skip when reporting the calling file and line. Can be used e.g. inside log functions.
 #' @return NULL (invisible)
-.vsc.cat <- function(...) {
+.vsc.cat <- function(..., skipCalls=0) {
   # TODO: consider correct environment for print(...)?
   # env <- sys.frame(-1)
   # ret <- capture.output(base::print(...), envir=env)
@@ -142,9 +143,9 @@ isPackageFrame <- function(env = parent.frame()) {
   ret <- capture.output(base::cat(...))
   output <- paste(ret, sep = "", collapse = "\n")
 
-  line <- .vsc.getLineNumber(sys.call())
+  line <- .vsc.getLineNumber(sys.call(-skipCalls))
   frame <- parent.frame()
-  call <- sys.call(-1)
+  call <- sys.call(-1 - skipCalls)
   file <- .vsc.getFileName(call, frame)
   # output <- capture.output(base::print(...))
   .vsc.sendToVsc('print', list(output = output, file = file, line = line))
@@ -156,8 +157,9 @@ isPackageFrame <- function(env = parent.frame()) {
 #' Captures the output of \code{print(...)} and sends it to vsc together with information about the sourcefile and line
 #' @export
 #' @param ... Arguments passed to \code{base::cat()}
+#' @param skipCalls The number of calls to skip when reporting the calling file and line. Can be used e.g. inside log functions.
 #' @return \code{NULL} (invisible)
-.vsc.print <- function(x, ...) {
+.vsc.print <- function(x, ..., skipCalls=0) {
   # TODO: consider correct environment for print(...)?
   # env <- sys.frame(-1)
   # ret <- capture.output(base::print(...), envir=env)
@@ -168,9 +170,9 @@ isPackageFrame <- function(env = parent.frame()) {
   ret <- capture.output(base::print(x, ...))
   output <- paste(ret, sep = "", collapse = "\n")
 
-  line <- .vsc.getLineNumber(sys.call())
+  line <- .vsc.getLineNumber(sys.call(-skipCalls))
   frame <- parent.frame()
-  call <- sys.call(-1)
+  call <- sys.call(-1 - skipCalls)
   file <- .vsc.getFileName(call, frame)
   # output <- capture.output(base::print(...))
   .vsc.sendToVsc('print', list(output = output, file = file, line = line))

--- a/man/dot-vsc.cat.Rd
+++ b/man/dot-vsc.cat.Rd
@@ -4,10 +4,12 @@
 \alias{.vsc.cat}
 \title{Modified version of \code{cat()} for vsc}
 \usage{
-.vsc.cat(...)
+.vsc.cat(..., skipCalls = 0)
 }
 \arguments{
 \item{...}{Arguments passed to base::cat()}
+
+\item{skipCalls}{The number of calls to skip when reporting the calling file and line. Can be used e.g. inside log functions.}
 }
 \value{
 NULL (invisible)

--- a/man/dot-vsc.print.Rd
+++ b/man/dot-vsc.print.Rd
@@ -4,10 +4,12 @@
 \alias{.vsc.print}
 \title{Modified version of \code{print()} for vsc}
 \usage{
-.vsc.print(x, ...)
+.vsc.print(x, ..., skipCalls = 0)
 }
 \arguments{
 \item{...}{Arguments passed to \code{base::cat()}}
+
+\item{skipCalls}{The number of calls to skip when reporting the calling file and line. Can be used e.g. inside log functions.}
 }
 \value{
 \code{NULL} (invisible)


### PR DESCRIPTION
Adds an argument `skipCalls` to `.vsc.print` and `.vsc.cat`.
Intended usecase is to provide more useful information e.g. from inside logging functions:
``` r
log <- function(...){
  .vsc.cat(..., skipCalls=1)
}

log("Log 1")
log("Log 2")
log("Log 3")
```
