### PR TITLE
Remove as.list.environment()

### DIFF
--- a/R/stack.R
+++ b/R/stack.R
@@ -513,8 +513,8 @@ getActiveBinding <- function(name, env){
   ret <- if (getRversion() >= "4.0.0") {
     activeBindingFunction(name, env)
   } else {
-    as.list.environment(env)[[name]]
-    # getInfoVar("R version >= 4.0.0 required to show active binding function!")
+    # as.list.environment(env)[[name]]
+    getInfoVar("R version >= 4.0.0 required to show active binding function!")
   }
   structure(list(bindingFunction = ret), class = '.vsc.activeBinding')
 }


### PR DESCRIPTION
Removes as.list.environment, since it forces the evaluation of promises in the environment (https://github.com/ManuelHentschel/vscDebugger/pull/49#discussion_r436967276).
Instead, a warning is shown.