### PR TITLE
Add evaluateName

### DIFF
--- a/R/customVarInfo.R
+++ b/R/customVarInfo.R
@@ -13,6 +13,7 @@
 #     shortType: ((v:rValue) => string)|string|NULL;
 #     longType: ((v:rValue) => string)|string|NULL;
 #     includeAttributes: ((v:rValue) => boolean)|boolean|NULL;
+#     evaluateName: ((v:rValue) => string)|string|NULL;
 # }
 # type varInfos = varInfo[];
 
@@ -33,6 +34,7 @@
   #     shortType
   #     longType
   #     includeAttributes
+  #     evaluateName
   ret <- default
   try({
     # loop through varInfos

--- a/R/defaultVarInfo.R
+++ b/R/defaultVarInfo.R
@@ -353,7 +353,8 @@ getDefaultVarInfos <- function() {
       hasChildren = function(v) !is.null(attributes(v)),
       toString = function(v) {
         paste0(utils::capture.output(utils::str(v, max.level = 0, give.attr = FALSE)), collapse = "\n")
-      }
+      },
+      evaluateName = function(v) paste0(deparse(v), collapse = '\n')
     )
   )
 

--- a/R/stack.R
+++ b/R/stack.R
@@ -621,13 +621,15 @@ getVariable <- function(valueR, name, depth = 20) {
   value <- varToString(valueR)
   type <- getType(valueR)
   variablesReference <- getVarRefForVar(valueR, depth)
+  evaluateName <- .vsc.getCustomInfo(valueR, 'evaluateName', '', '')
 
   variable <- list(
     name = name,
     value = value,
     type = type,
     variablesReference = variablesReference,
-    depth = depth
+    depth = depth,
+    evaluateName = evaluateName
   )
   return(variable)
 }


### PR DESCRIPTION
Adds a varInfo entry `evaluateName` which can be used to copy variables to clipboard.