### PR TITLE
Use tinytest instead of testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,4 @@ Imports:
 KeepSource: TRUE
 NeedsCompilation: yes
 Suggests: 
-    testthat
+    tinytest

--- a/inst/tinytest/test_buildStack.R
+++ b/inst/tinytest/test_buildStack.R
@@ -1,0 +1,5 @@
+
+# test basic structure
+stack <- .vsc.buildStack()
+expect_identical(class(stack), "list")
+expect_identical(names(stack), c("frames", "varLists"))

--- a/tests/test.R
+++ b/tests/test.R
@@ -1,2 +1,0 @@
-devtools::load_all()
-stack <- .vsc.buildStack()

--- a/tests/tinytest.R
+++ b/tests/tinytest.R
@@ -1,0 +1,5 @@
+
+if ( requireNamespace("tinytest", quietly=TRUE) ){
+  tinytest::test_package("vscDebugger")
+}
+


### PR DESCRIPTION
Relates to #35 

You can find a basic intro to tinytest [here](https://github.com/markvanderloo/tinytest/blob/master/pkg/README.md). 

For now, I only transformed the current (minimal) `.vsc.buildStack` test. You can test it by:
```r
tinytest::build_install_test()
```
This call re-builds the package first, then runs the test.

I do not know the best strategy for writing unit tests for **vscDebugger**. In general, one tests the exported functions of a package (that is, the user-visible part, aka the API of the package). However, here the use case is different, since the exported functions will be called by the R Debugger VSCode extension. So maybe we could distinguish between three (or four?) sets of functions:

1. Functions for communicating with the **R Debugger** extension (exported for technical reasons): I am not familiar enough with the R Debugger part to decide what level of details shall be tested and how.  

1. Workhorse functions in the **vscDebugger** package, which might be of interest for non-VSC users as well (e.g., `getVarsInEnv` or `getVarInEnv`): these could be exported, and tested as standard R functions.  

1. Internal functions: not exported, not tested directly, but should be documented (with `#' @keywords internal`) to aid further contributors. 
