### PR TITLE
Ellipses and names

### DIFF
--- a/R/buildStack.R
+++ b/R/buildStack.R
@@ -266,6 +266,7 @@ buildVariable <- function(args){
   )
 
   allVars <- c(childVars, attrVars)
+  allVars <- fixNames(allVars)
 
   nodeArgs <- lapply(allVars, function(v){
     list(contentArgs = list(minVar = v))

--- a/R/buildStackHelpers.R
+++ b/R/buildStackHelpers.R
@@ -152,3 +152,16 @@ getScopeEnvs <- function(firstenv = parent.frame(), lastenv = .GlobalEnv) {
 }
 
 
+fixNames <- function(childVars){
+  names <- lapply(childVars, function(var) var$name)
+  inds <- which(duplicated(names) | names == "")
+  while(length(inds)>0){
+    for(ind in inds){
+      newName <- paste0(names[[ind]], "<", ind, ">")
+      childVars[[ind]]$name <- newName
+      names[[ind]] <- newName
+    }
+    inds <- which(duplicated(names))
+  }
+  return(childVars)
+}

--- a/R/defaultVarInfo.R
+++ b/R/defaultVarInfo.R
@@ -58,36 +58,12 @@ getDefaultVarInfos <- function() {
         )
       }
     ),
-    # Ellipses entry (custom type)
+    # Ellipsis (custom type)
     list(
-      name = 'EllipsesEntry',
-      doesApply = function(v) inherits(v, '.vsc.ellipsesEntry'),
-      includeAttributes = FALSE,
-      internalAttributes = function(v) list(
-        list(
-          name = '__dotEnvironment',
-          rValue = v$dotEnv
-        )
-      ),
-      childVars = list(),
-      longType = 'ellipses entry',
-      shortType = '',
-      toString = function(v) paste0(format(v$dotExpr), collapse = '\n')
-    ),
-    # Ellipses (custom type)
-    list(
-      name = 'Ellipses',
-      doesApply = function(v) inherits(v, '.vsc.ellipses'),
-      childVars = function(v) {
-        lapply(v, function(vv) {
-          class(vv) <- c('.vsc.ellipsesEntry', '.vsc.internalClass')
-          list(
-            rValue = vv,
-            name = '<Ellipses Entry Name???>'
-          )
-        })
-      },
-      longType = 'ellipses',
+      name = 'Ellipsis',
+      doesApply = function(v) inherits(v, '.vsc.ellipsis'),
+      longType = 'ellipsis',
+      toString = '<Ellipsis Arguments>',
       includeAttributes = FALSE,
       internalAttributes = list()
     ),

--- a/R/defaultVarInfoHelpers.R
+++ b/R/defaultVarInfoHelpers.R
@@ -114,24 +114,7 @@ getDotVars <- function(env) {
   ## Note: substitute(...()) is officially not supported, but it 
   ## works as intended for all relevant R versions (at least from R 3.0.0)
   dots <- substitute(...(), env = env)
-  ret <- lapply(
-    dots, 
-    function(x) {
-      list(
-        dotExpr = x,
-        dotCode = tryCatch(
-          ##TODO: use proper formatting function
-          paste0(toString(x), collapse = ";"), 
-          error = function(e) {
-            "???"
-          }
-        ),
-        ##TODO: which environment do we want to display here?
-        dotEnv = env
-      )
-    }
-  )
-  structure(ret, class = ".vsc.ellipses")
+  structure(dots, class = c(".vsc.ellipsis", ".vsc.internalClass"))
 } 
 
 #' Get a representation of a promise

--- a/R/setVar.R
+++ b/R/setVar.R
@@ -28,7 +28,7 @@ setVariableRequest <- function(response, args, request){
     } else{
       response$success <- FALSE
       if(is.null(successAndRValue$reason)){
-        cat("Changing the variable value was not successful.\n", file = stderr())
+        cat("<Changing the variable value was unsuccessful>\n", file = stderr())
       } else{
         cat(successAndRValue$reason, file = stderr())
       }
@@ -46,7 +46,7 @@ setVar <- function(setInfos, valueString){
   reason <- NULL
   if(is.null(target) || is.null(env)){
     success <- FALSE
-    reason <- "No set-info available.\n"
+    reason <- "<No set-info available>\n"
   } else{
     err <- try({
       tmpTracingState <- tracingState(FALSE)


### PR DESCRIPTION
Fixes the display of duplicate child variable names, (e.g. `list(b=0, a=1, a=2, a=3)`) by appending the 1-based position to duplicate variable names (e.g. `b`, `a`, `a<3>`, `a<4>`). Changing the variable name is necessary since VS-Code/the DAP does not support child variables with identical names.

Fixes the display of ellipsis arguments.

Changes the info texts printed by setVar.R