### PR TITLE
Fix deletion of environment attributes

### DIFF
--- a/R/defaultVarInfo.R
+++ b/R/defaultVarInfo.R
@@ -257,7 +257,9 @@ getDefaultVarInfos <- function() {
     list(
       name = 'Vector',
       doesApply = function(v) {
-        if(is.factor(v)){
+        if(is.environment(v)){
+          FALSE
+        } else if(is.factor(v)){
           FALSE
         } else{
           attributes(v) <- NULL


### PR DESCRIPTION
Fixes an issue where the check if a variable is a vector (globally) deletes the attributes of an environment