### PR TITLE
Add option to group attributes

### DIFF
--- a/R/defaultVarInfo.R
+++ b/R/defaultVarInfo.R
@@ -405,6 +405,9 @@ getDefaultVarInfos <- function() {
       nChildVars = 0,
       type = function(v) typeof(v),
       internalAttributes = function(v) {
+        if(getOption('vsc.groupAttributes', FALSE)){
+          return(list())
+        }
         attr <- attributes(v)
         names <- names(attr)
         mapply(
@@ -421,7 +424,20 @@ getDefaultVarInfos <- function() {
           USE.NAMES = FALSE
         )
       },
-      customAttributes = list(),
+      customAttributes = function(v){
+        if(getOption('vsc.groupAttributes', FALSE) && !inherits(v, '.vsc.internalClass')){
+          rValue <- attributes(v)
+          class(rValue) <- c('.vsc.attributeList', '.vsc.internalClass')
+          ret <- list(
+            name = "__attributes()",
+            rValue = rValue,
+            setter = quote(attributes(parent))
+          )
+          list(ret)
+        } else{
+          list()
+        }
+      },
       toString = function(v) {
         paste0(utils::capture.output(utils::str(v, max.level = 0, give.attr = FALSE)), collapse = "\n")
       },

--- a/R/defaultVarInfoHelpers.R
+++ b/R/defaultVarInfoHelpers.R
@@ -157,7 +157,7 @@ getDotVars <- function(env) {
 getPromiseVar <- function(name, env) {
   structure(
     getPromiseInfo(name, env),
-    class = c(".vsc.promise", ".vsc.InternalClass")
+    class = c(".vsc.promise", ".vsc.internalClass")
   )
 }
 


### PR DESCRIPTION
#66 
Adds the option `vsc.groupAttributes = FALSE | TRUE` which (if set to `TRUE`) introduces a custom attribute `__attributes()` that contains all the internal attributes and disables the normal display of internal attributes.

Is only applied in the default VarInfo, so there might be some cases I missed.
