### PR TITLE
Fix file warnings/errors

### DIFF
--- a/R/breakpointManagement.R
+++ b/R/breakpointManagement.R
@@ -17,7 +17,7 @@ setBreakpointsRequest <- function(response, args, request){
 
 requestArgsToFileBreakpoints <- function(args){
   # not supported: args$lines
-  path <- normalizePath(lget(args$source, 'path', ''))
+  path <- normalizePath(lget(args$source, 'path', ''), mustWork=FALSE)
   args$source$path <- path
   args$breakpoints <- lapply(args$breakpoints, sourceBreakpointToInternalBreakpoint, args$source)
   return(args)
@@ -88,7 +88,7 @@ getRequestedBreakpointLines <- function(path){
 .vsc.setStoredBreakpoints <- function() {
   for (fbp in session$fileBreakpoints){
     file <- lget(fbp$source, 'path', '')
-    if(file != ''){
+    if(file.exists(file)){
       bps <- lget(fbp, 'breakpoints', list())
       includePackageScopes <- lget(session, 'setBreakpointsInPackages', FALSE)
       .vsc.setBreakpoints(file, bps, includePackageScopes = includePackageScopes)

--- a/R/launch.R
+++ b/R/launch.R
@@ -150,8 +150,13 @@ launchRequest <- function(response, args, request){
   setwd(session$workingDirectory)
 
   file <- lget(args, 'file', 'main.R')
-  file <- normalizePath(file) # make sure to setwd() first!
+  file <- normalizePath(file, mustWork=FALSE) # make sure to setwd() first!
   session$file <- file
+
+  if(!file.exists(file) && session[['debugMode']] %in% c('function', 'file')){
+    response$success <- FALSE
+    response$message <- paste0("The file ", file, " could not be found!")
+  }
 
   ## do stuff
   # check debugMode

--- a/R/stackHelpers.R
+++ b/R/stackHelpers.R
@@ -55,7 +55,7 @@ getSource <- function(call, frameIdR = 0) {
   )
 }
 
-normalizePathInWd <- function(path, winslash="\\", mustWork=NA, wd=NULL){
+normalizePathInWd <- function(path, winslash="\\", mustWork=FALSE, wd=NULL){
   if(is.null(wd)){
     ret <- normalizePath(path, winslash, mustWork)
   } else{

--- a/build.R
+++ b/build.R
@@ -1,7 +1,7 @@
 devtools::document()
 devtools::install(
   dependencies = FALSE,
-  quick=TRUE,
+  # quick=TRUE,
   keep_source=TRUE,
   args="--no-byte-compile"
 )


### PR DESCRIPTION
Fixes https://github.com/ManuelHentschel/VSCode-R-Debugger/issues/69 ?

The debugger now checks if a file exists before trying to launching a debug session or setting a breakpoint in a file.
