### PR TITLE
Fix missing childVars

### DIFF
--- a/R/defaultVarInfo.R
+++ b/R/defaultVarInfo.R
@@ -80,6 +80,12 @@ getDefaultVarInfos <- function() {
       childVars = list(),
       nChildVars = 0
     ),
+    # R6 (TODO: display public/private properties etc.)
+    list(
+      name = 'R6',
+      doesApply = function(v) inherits(v, 'R6'),
+      type = 'R6'
+    ),
     # environment
     list(
       name = 'Environment',
@@ -314,7 +320,15 @@ getDefaultVarInfos <- function() {
         ret
       }
     ),
-    # S4
+    # S4 class representation
+    list(
+      name = 'S4 class representation',
+      doesApply = function(v) inherits(v, 'classRepresentation') && isS4(v),
+      childVars = list(),
+      nChildVars = 0,
+      type = 'S4 class representation'
+    ),
+    # S4 (instance or class representation. Child vars of S4 class representation handled above.)
     list(
       name = 'S4',
       doesApply = isS4,

--- a/R/stackTree.R
+++ b/R/stackTree.R
@@ -537,11 +537,22 @@ VariableNode <- R6::R6Class(
 
       # combine with old vars
       newVars <- lapply(seq_along(missingIndices), function(i){
-        list(
-          index=missingIndices[i],
-          minVar=infos[['childVars']][[i]],
-          node=NULL
-        )
+        if(i<=length(infos[['childVars']])){
+          list(
+            index=missingIndices[i],
+            minVar=infos[['childVars']][[i]],
+            node=NULL
+          )
+        } else{
+          list(
+            index=missingIndices[i],
+            minVar=list(
+              name="<WARNING>",
+              rValue=getInfoVar("<Some child variables might be missing!>")
+            ),
+            node=NULL
+          )
+        }
       })
       vars <- c(vars, newVars)
       savedIndices <- c(savedIndices, missingIndices)
@@ -566,6 +577,7 @@ VariableNode <- R6::R6Class(
       } else{
         self$attrVars <- vars
       }
+
       return(nodes)
     },
     getChildren = function(args=list()){


### PR DESCRIPTION
Fix #97 

Checks if `VarInfo$childVars()` actually returns the number of chidlren promised by `VarInfo$nChildVars()` and gracefully handles missing entries by showing an info variable with a warning/error message.

Adds VarInfos for `S4 class representation` and `R6`.