### PR TITLE
Add max size for deparsed objects

### DIFF
--- a/R/defaultVarInfo.R
+++ b/R/defaultVarInfo.R
@@ -455,7 +455,16 @@ getDefaultVarInfos <- function() {
       toString = function(v) {
         paste0(utils::capture.output(utils::str(v, max.level = 0, give.attr = FALSE)), collapse = "\n")
       },
-      evaluateName = function(v) paste0(deparse(v), collapse = '\n')
+      evaluateName = function(v) {
+        bytes <- object.size(v)
+        maxBytes <- getOption('vsc.deparseMaxBytes', 1e5)
+        if(bytes <= maxBytes){
+          ret <- paste0(deparse(v), collapse = '\n')
+        } else{
+          ret <- '<Object too large>'
+        }
+        return(ret)
+      }
     )
   )
 


### PR DESCRIPTION
Adds a check to avoid deparsing large objects (e.g. vectors with 10,000+ entries) when providing an `evaluateName`.
Uses `object.size` since it's the best proxy for "deparse-cost" I could think of.
If there are variable types with better proxies, we could implement those individually.