### PR TITLE
Empty sources

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
 Imports:
     jsonlite(>= 1.6.0), R6
-KeepSource: TRUE
 NeedsCompilation: yes
 Suggests: 
     tinytest

--- a/R/stackTreeHelpers.R
+++ b/R/stackTreeHelpers.R
@@ -77,6 +77,9 @@ getSource <- function(call, frameIdR = 0) {
     src$path <- path
   } else{
     content <- paste0(srcfile$lines, collapse='\n')
+    if(identical(content, '')){
+      return(NULL)
+    }
     src$content <- content
     # src$path <- 'temp'
     # src$name <- 'temp'


### PR DESCRIPTION
* Properly handle empty sources. These occurr with functions from packages that were installed from `.tar.gz` etc., but retained (some) source information
* Remove KeepSource from Description -> compiled packages do not contain source references in vsc functions
