### PR TITLE
Invalidated event

### DIFF
--- a/R/communications.R
+++ b/R/communications.R
@@ -47,6 +47,10 @@ sendToVsc <- function(body = "") {
   j <- getJson(body)
   if(!is.null(session$jsonServerConnection)){
     base::cat(j, '\n', sep='', file=session$jsonServerConnection)
+    logCat('Sent json: ', j, '\n', sep='')
+    TRUE
+  } else{
+    FALSE
   }
 }
 
@@ -57,12 +61,19 @@ getJson <- function(body){
 
 removeNonJsonElements <- function(v){
   if(is.list(v)){
-    lapply(v, removeNonJsonElements)
+    v <- lapply(v, removeNonJsonElements)
+    # remove NULL entries
+    for(i in rev(seq_along(v))){
+      if(is.null(v[[i]])){
+        v[i] <- NULL
+      }
+    }
+    return(v)
   } else{
     if(is.vector(v)){
-      v
+      return(v)
     } else{
-      ''
+      return(NULL)
     }
   }
 }

--- a/R/debugAdapter.R
+++ b/R/debugAdapter.R
@@ -9,13 +9,13 @@
   obj <- jsonlite::fromJSON(json, simplifyVector = FALSE)
   if(lget(obj, 'type', '') == 'request'){
     .vsc.dispatchRequest(obj)
-    success <- TRUE
+    typeKnown <- TRUE
   } else{
     logCat('Unknown json: ', json, '\n')
-    success <- FALSE
+    typeKnown <- FALSE
   }
   unregisterEntryFrame()
-  invisible(success)
+  invisible(typeKnown)
 }
 
 #' @export
@@ -24,7 +24,7 @@
   response <- prepareResponse(request)
   command <- lget(request, 'command', '')
   args <- lget(request, 'arguments', list())
-  success <- TRUE
+  commandKnown <- TRUE
   if(command == 'stackTrace'){
     stackTraceRequest(response, args, request)
   } else if(command == 'scopes'){
@@ -66,16 +66,16 @@
   } else if(command == 'terminate'){
     terminateRequest(response, args, request)
   } else if(command == 'disconnect'){
-    disconnectRequest(response, args, request) # different form terminate?
+    disconnectRequest(response, args, request)
   } else if(command == 'custom'){
     customRequest(response, args, request)
   } else {
-    success <- FALSE
+    commandKnown <- FALSE
     response$success <- FALSE
     sendResponse(response)
   }
   unregisterEntryFrame()
-  invisible(success)
+  invisible(commandKnown)
 }
 
 prepareResponse <- function(request){

--- a/R/debugAdapter.R
+++ b/R/debugAdapter.R
@@ -187,6 +187,22 @@ sendCustomEvent <- function(reason=NULL, body=list()){
   sendEvent(makeCustomEvent(reason, body))
 }
 
+makeInvalidatedEvent <- function(areas=list('all'), threadId=NULL, stackFrameId=NULL){
+  event <- makeEvent('invalidated')
+  event$body <- list(
+    areas = areas,
+    threadId = threadId,
+    stackFrameId = stackFrameId
+  )
+  event
+}
+sendInvalidatedEvent <- function(areas=list('all'), threadId=NULL, stackFrameId=NULL){
+  if(session$supportsInvalidatedEvent){
+    sendEvent(makeInvalidatedEvent(areas, threadId, stackFrameId))
+  } else{
+    FALSE
+  }
+}
 
 makeStoppedEvent <- function(reason="breakpoint", description=NULL, text=NULL){
   event <- makeEvent("stopped")

--- a/R/global.R
+++ b/R/global.R
@@ -13,7 +13,8 @@ session <- local({
   overwriteStr <- TRUE
   overwriteSource <- TRUE
 
-  noDebug <- FALSE # currently not used
+  supportsInvalidatedEvent <- FALSE
+  noDebug <- FALSE
   debugMode <- NULL
   workingDirectory <- NULL
   file <- NULL

--- a/R/launch.R
+++ b/R/launch.R
@@ -82,6 +82,8 @@ initializeRequest <- function(response, args, request){
   )
   sink(session$sinkServerConnection)
 
+  session$supportsInvalidatedEvent <- lget(args, 'supportsInvalidatedEvent', FALSE)
+
   session$threadId <- lget(args, 'threadId', 1)
 
   response$body <- body

--- a/R/setVar.R
+++ b/R/setVar.R
@@ -46,7 +46,9 @@ setVariableRequest <- function(response, args, request){
       }
     }
   }
-  sendResponse(response)
+  ret <- sendResponse(response)
+  sendInvalidatedEvent(list('variables')) # update other variables to cover side effects
+  invisible(ret)
 }
 
 

--- a/d.ts/debugAdapter.d.ts
+++ b/d.ts/debugAdapter.d.ts
@@ -3,21 +3,26 @@ import { DebugProtocol } from './debugProtocol'
 
 export declare module DebugAdapter {
 
-  function _vsc_handleJson(json: string): void;
+  // return indicates whether the message type was known (only true for 'request')
+  function _vsc_handleJson(json: string): boolean;
 
-  function _vsc_dispatchRequest(request: DebugProtocol.Request): void;
+  // return indicates whether the request command was known
+  function _vsc_dispatchRequest(request: DebugProtocol.Request): boolean;
 
-  function sendResponse(response: DebugProtocol.Response): void;
+  // return indicates whether the response was successfully sent
+  function sendResponse(response: DebugProtocol.Response): boolean;
 
   function prepareResponse(request: DebugProtocol.Request): DebugProtocol.Response;
 
+  // if present, the return value indicates whether the corresponding response was successfully sent
   function genericRequest(
     response: DebugProtocol.Response,
     args: {[key: string]: any},
     request: DebugProtocol.Request
-  ): void;
+  ): boolean|void;
 
   function makeEvent(eventType: string, body: any): DebugProtocol.Event;
 
-  function sendEvent(event: DebugProtocol.Event): void;
+  // return indicates whether the event was successfully sent
+  function sendEvent(event: DebugProtocol.Event): boolean;
 }

--- a/d.ts/global.d.ts
+++ b/d.ts/global.d.ts
@@ -21,6 +21,7 @@ export declare module Session {
     overwriteMessage: boolean;
     overwriteSource: boolean;
 
+    supportsInvalidatedEvent: boolean;
     noDebug: boolean; 
     debugMode: ("function" | "file" | "workspace")
     workingDirectory: string;


### PR DESCRIPTION
Adds support for the new `invalidatedEvent`.

This event is sent after setting a variable to properly display side effects of variable assignments (e.g. assigning a new `dim` to an array affects all other child variables of the array as well).
