### PR TITLE
Fix changed wd in normalizePathInWd()

### DIFF
--- a/R/stackTreeHelpers.R
+++ b/R/stackTreeHelpers.R
@@ -114,7 +114,7 @@ normalizePathInWd <- function(path, winslash="\\", mustWork=FALSE, wd=NULL){
         ret
       },
       error = function(e) path,
-      finally = function(...) setwd(tmpwd)
+      finally = setwd(tmpwd)
     )
   }
   ret

--- a/R/stackTreeHelpers.R
+++ b/R/stackTreeHelpers.R
@@ -109,12 +109,11 @@ normalizePathInWd <- function(path, winslash="\\", mustWork=FALSE, wd=NULL){
   } else{
     ret <- tryCatch(
       {
-        tmpwd <- getwd()
-        setwd(wd)
+        tmpwd <- setwd(wd)
+        on.exit(setwd(tmpwd))
         normalizePath(path, winslash, mustWork)
       },
-      error = function(e) path,
-      finally = setwd(tmpwd)
+      error = function(e) path
     )
   }
   ret

--- a/R/stackTreeHelpers.R
+++ b/R/stackTreeHelpers.R
@@ -110,9 +110,8 @@ normalizePathInWd <- function(path, winslash="\\", mustWork=FALSE, wd=NULL){
     ret <- tryCatch(
       {
         tmpwd <- getwd()
-        tmpwd <- setwd(wd)
-        ret <- normalizePath(path, winslash, mustWork)
-        ret
+        setwd(wd)
+        normalizePath(path, winslash, mustWork)
       },
       error = function(e) path,
       finally = setwd(tmpwd)

--- a/R/stackTreeHelpers.R
+++ b/R/stackTreeHelpers.R
@@ -109,6 +109,7 @@ normalizePathInWd <- function(path, winslash="\\", mustWork=FALSE, wd=NULL){
   } else{
     ret <- tryCatch(
       {
+        tmpwd <- getwd()
         tmpwd <- setwd(wd)
         ret <- normalizePath(path, winslash, mustWork)
         ret


### PR DESCRIPTION
Fixes #122 

There was an error in `normalizePathInWd`, where a function instead of an expression was supplied as `finally` argument in `tryCatch`.
