### PR TITLE
Bug fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ BugReports: https://github.com/ManuelHentschel/vscDebugger/issues
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Imports:
     jsonlite(>= 1.6.0), R6
 NeedsCompilation: yes

--- a/R/flow.R
+++ b/R/flow.R
@@ -164,6 +164,7 @@ stepOutRequest <- function(response, args, request){
 disconnectRequest <- function(response, args, request){
   doQuit <- session$state$baseState != 'attached'
   session$state$changeBaseState('quitting')
+  options(error = NULL)
 
   if(!doQuit){
     logPrint('disconnect from attached session')
@@ -220,6 +221,7 @@ terminateSessionFromTopLevel <- function(){
 
 sessionFinalizer <- function(...){
   if(session$state$baseState != 'quitting'){
+    options(error = NULL)
     try(detach(session$rStrings$attachName, character.only = TRUE), silent = TRUE)
     try(sendExitedEvent(), silent = TRUE)
     try(sendTerminatedEvent(), silent = TRUE)

--- a/R/frameManagement.R
+++ b/R/frameManagement.R
@@ -119,10 +119,10 @@ convertFrameId <- function(vsc = NULL, R = NULL) {
   if (is.null(vsc) && is.null(R)) {
     return(NULL)
   } else if (is.null(vsc)) {
-    frame <- session$rootNode$getStackNode()$getChildren(list(frameIdR=R))
+    frame <- session$rootNode$getStackNode()$getChildren(list(frameIdR=R))[[1]]
     return(frame$frameIdVsc)
   } else {
-    frame <- session$rootNode$getStackNode()$getChildren(list(frameId=vsc))
+    frame <- session$rootNode$getStackNode()$getChildren(list(frameId=vsc))[[1]]
     return(frame$frameIdR)
   }
 }

--- a/R/launch.R
+++ b/R/launch.R
@@ -166,6 +166,7 @@ launchRequest <- function(response, args, request){
       ret <- try(
         library(package=pkg, character.only=TRUE)
       )
+      avoidLazyLoading(pkg)
       if(inherits(ret, 'try-error')){
         response$success <- FALSE
         response$message <- paste0("Package not found: ", pkg)

--- a/R/stackTreeHelpers.R
+++ b/R/stackTreeHelpers.R
@@ -50,6 +50,8 @@ getSource <- function(call, frameIdR = 0) {
       logPrint('found srcref but not srcfile!!!')
       logPrint(srcref)
       logPrint(call)
+    } else{
+      logPrint('no srcfile!!!!')
     }
     return(NULL)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,3 +64,11 @@ isCalledFromBrowser <- function(){
 assignOverBinding <- function(what, value, where, verbose = TRUE){
   methods:::.assignOverBinding(what, value, where, verbose)
 }
+
+avoidLazyLoading <- function(package){
+  ns <- getNamespace(package)
+  for(name in ls(ns)){
+    get(name, envir=ns)
+  }
+  invisible(NULL)
+}


### PR DESCRIPTION
1. Some small bug fixes
2. Add function `avoidLazyLoading` that evaluates (not "calls"!) every item in the scope of a package once, to avoid complications caused by lazy loading of functions etc.