### PR TITLE
Repurpose reverseContinueRequest

### DIFF
--- a/R/debugAdapter.R
+++ b/R/debugAdapter.R
@@ -45,6 +45,8 @@
     stepInRequest(response, args, request)
   } else if(command == 'stepOut'){
     stepOutRequest(response, args, request)
+  } else if(command == 'reverseContinue'){
+    reverseContinueRequest(response, args, request)
   } else if(command == 'restart'){
     restartRequest(response, args, request)
   } else if(command == 'terminate'){

--- a/R/debugAdapter.R
+++ b/R/debugAdapter.R
@@ -247,17 +247,23 @@ sendExitedEvent <- function(exitCode=0){
 }
 
 makeTerminatedEvent <- function(restart=NULL){
-  event <- makeEvent("terminated")
-  event$body <- list()
-  event$body$restart <- restart
-  event
+  makeEvent("terminated", list(restart = restart))
 }
 sendTerminatedEvent <- function(restart=NULL){
   sendEvent(makeTerminatedEvent(restart))
 }
 
+makeCapabilitiesEvent <- function(capabilities){
+  makeEvent('capabilities', list(
+    capabilities = capabilities
+  ))
+}
+sendCapabilitesEvent <- function(capabilities){
+  sendEvent(makeCapabilitiesEvent(capabilities))
+}
+
 makeWriteToStdinEvent <- function(text='', when='now', addNewLine=TRUE, expectPrompt=NULL, count=1, stack=FALSE, fallBackToNow=FALSE){
-  event <- makeCustomEvent('writeToStdin', list(
+  makeCustomEvent('writeToStdin', list(
     text = text,
     when = when,
     fallBackToNow = fallBackToNow,

--- a/R/flow.R
+++ b/R/flow.R
@@ -213,6 +213,17 @@ terminateRequest <- function(response, args, request){
 }
 
 
+reverseContinueRequest <- function(response, args, request){
+  if(isCalledFromBrowser()){
+    success <- sendWriteToStdinForFlowControl('Q')
+    session$stopListeningOnPort <- success
+    response$success <- success
+  } else{
+    response$success <- FALSE
+  }
+  sendResponse(response)
+}
+
 terminateSessionFromTopLevel <- function(){
   session$state$changeBaseState('quitting')
   sendTerminatedEvent()

--- a/R/getStack.R
+++ b/R/getStack.R
@@ -5,9 +5,6 @@ stackTraceRequest <- function(response, args, request){
   startFrame <- lget(args, 'startFrame', 0)
   levels <- lget(args, 'levels', -1)
 
-  Sys.sleep(lget(globalenv(), 'tempWait0', 0))
-  
-
   topFrameId <- getTopFrameId()
   skipFromBottom <- getSkipFromBottom()
   if(getOption('vsc.showInternalFrames', FALSE)){

--- a/R/launch.R
+++ b/R/launch.R
@@ -12,15 +12,13 @@ initializeRequest <- function(response, args, request){
   # support terminate: can be used to exit function without terminating R session
   # only works ONCE (!)
   body$supportsTerminateRequest <- getOption('vsc.supportTerminateRequest', FALSE)
+  body$supportsStepBack <- getOption('vsc.repurposeReverseContinue', FALSE)
 
   # the adapter implements the configurationDoneRequest.
   body$supportsConfigurationDoneRequest <- TRUE
 
   # make VS Code NOT use 'evaluate' when hovering over source
   body$supportsEvaluateForHovers <- FALSE
-
-  # make VS Code NOT show a 'step back' button
-  body$supportsStepBack <- FALSE
 
   # make VS Code NOT support data breakpoints
   body$supportsDataBreakpoints <- FALSE

--- a/R/launch.R
+++ b/R/launch.R
@@ -220,6 +220,13 @@ launchRequest <- function(response, args, request){
 configurationDoneRequest <- function(response, args, request){
   # no args
 
+  # update capabilities that might have been changed by loaded user code
+  capabilities <- list()
+  capabilities$supportsTerminateRequest <- getOption('vsc.supportTerminateRequest', FALSE)
+  capabilities$supportsStepBack <- getOption('vsc.repurposeReverseContinue', FALSE)
+  capabilities$supportsSetVariable <- getOption('vsc.supportSetVariable', TRUE)
+  sendCapabilitesEvent(capabilities)
+
   # overwrite requested functions
   attachList <- list()
 


### PR DESCRIPTION
This PR repurposes the reverseContinueRequest to exit from the currently executed function without terminating the entire debug session (only sensible when `allowGlobalDebugging = true`).

Since this behaviour is not what the reverseContinueRequest is actually intended for, the feature is disabled by default and can be enabled by setting `options(vsc.repurposeReverseContinue = TRUE)`.