### PR TITLE
Specify how to print variables in debug console

### DIFF
--- a/R/defaultVarInfo.R
+++ b/R/defaultVarInfo.R
@@ -111,6 +111,17 @@ getDefaultVarInfos <- function() {
       },
       toString = format
     ),
+    # help file
+    list(
+      name = 'HelpFile',
+      doesApply = function(v){
+        identical(class(v), 'help_files_with_topic') ||
+        identical(class(v), 'hsearch')
+      },
+      printFunc = function(v) {
+        base::print
+      }
+    ),
     # factor
     list(
       name = 'Factor',
@@ -223,7 +234,14 @@ getDefaultVarInfos <- function() {
           paste0(utils::capture.output(utils::str(v, max.level = 0, give.attr = FALSE)), collapse = "\n")
         }
       },
-      type = 'array'
+      type = 'array',
+      printFunc = function(v){
+        if(getOption('vsc.printArrays', FALSE)){
+          base::print
+        } else{
+          NULL
+        }
+      }
     ),
     # list
     list(
@@ -490,6 +508,13 @@ getDefaultVarInfos <- function() {
           ret <- '<Object too large>'
         }
         return(ret)
+      },
+      printFunc = function(v) {
+        if(identical(getOption('vsc.printEvalResponses', FALSE), TRUE)){
+          base::print
+        } else{
+          TRUE
+        }
       }
     )
   )

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -125,6 +125,15 @@ evalInEnv <- function(
     }
   }
 
+  # return early if body is empty
+  if(length(body) == 0){
+    valueAndVisible <- list(
+      value = NULL,
+      visible = FALSE
+    )
+    return(valueAndVisible)
+  }
+
   # change state
   prevState <- session$state$startRunning('eval', evalSilent = !showOutput)
 
@@ -134,18 +143,12 @@ evalInEnv <- function(
     sendWriteToStdinEvent('c', when='browserPrompt', count=-1)
   }
     
-  valueAndVisible0 <- list(
-    value = NULL,
-    visible = FALSE
-  )
-
   # eval
   if(catchErrors && !showOutput){
     registerLaunchFrame(8)
     # wrap in try(), withVisible(), capture.output()
     valueAndVisible <- try(
       {
-        valueAndVisible <- valueAndVisible0
         for(exp in body){
           cl <- call('withVisible', exp)
           capture.output(valueAndVisible <- eval(cl, envir=env))
@@ -160,7 +163,6 @@ evalInEnv <- function(
     # wrap in try(), withVisible()
     valueAndVisible <- try(
       {
-        valueAndVisible <- valueAndVisible0
         for(exp in body){
           cl <- call('withVisible', exp)
           valueAndVisible <- eval(cl, envir=env)
@@ -173,7 +175,6 @@ evalInEnv <- function(
   } else{
     # wrap in withVisible()
     registerLaunchFrame(2)
-    valueAndVisible <- valueAndVisible0
     for(exp in body){
       cl <- call('withVisible', exp)
       valueAndVisible <- eval(cl, envir=env)

--- a/d.ts/customVarInfo.d.ts
+++ b/d.ts/customVarInfo.d.ts
@@ -25,6 +25,8 @@ export interface VarInfo {
   type?: ValueOrFunction<string>;
   // Expression that can be evaluated to get the variable value. Used to copy variable as expression
   evaluateName?: ValueOrFunction<string>;
+  // function that can be used to print/show the variable in the debug console
+  printFunc?: RFunction | boolean;
 }
 
 export function _vsc_applyVarInfo(


### PR DESCRIPTION
Adds an entry to VarInfos that specifies how a variable is printed in the debug console.
By default, this is done using the body of the EvaluateResponse, but might can be changed to use e.g. base::print.
Currently, this can be toggled for arrays or all variables using the options `vsc.printEvalResponses` and `vsc.printArrays`.