### PR TITLE
Update docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
 Suggests: 
     pkgload,
     knitr,
-    rmarkdown
+    rmarkdown,
+    markdown
 Encoding: UTF-8
 LazyData: true
 NeedsCompilation: yes

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -40,5 +40,16 @@ When launching the debugger, detailed logs are printed to the output channel
 "R Debugger" (`ctrl+shift+u` -> select `R Debugger` in the top right dropdown).
 These are not meant to be particularly descriptive for users, but might point you in the right direction.
 
+Problems that might be caused by timing issues,
+e.g. a slow R startup or network delay when working with remote servers,
+can sometimes be mitigated by increasing the timeout related settings:
+``` json
+{
+  "r.debugger.timeouts.prompt": 0,
+  "r.debugger.timeouts.startup": 2000,
+  "r.debugger.timeouts.terminate": 50,
+}
+```
+
 If you don't get the debugger running properly yourself,
 please don't hesitate to open an issue on github!

--- a/vignettes/vscode-R-Debugger.Rmd
+++ b/vignettes/vscode-R-Debugger.Rmd
@@ -38,7 +38,7 @@ After installing the extension, the R package can be installed using the command
 If this does not work, you can find the source code and compiled binaries on the
 [releases site](https://github.com/ManuelHentschel/VSCode-R-Debugger/releases).
 
-The provided packages were built using R 4.0.2 and might be incompatible with older R versions.
+The provided packages were built using the latest R release and might be incompatible with older R versions.
 In these cases it is necessary to build the package from code.
 
 If you want to install a development version, the VS Code extension can be installed from the .vsix-files found 

--- a/vignettes/vscode-R-Debugger.Rmd
+++ b/vignettes/vscode-R-Debugger.Rmd
@@ -7,7 +7,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-This extension adds debugging capabilities for the
+The extension [vscode-R-debugger](https://marketplace.visualstudio.com/items?itemName=RDebugger.r-debugger) adds debugging capabilities for the
 [R](https://www.r-project.org/)
 programming language to Visual Studio Code
 and depends on the R package [vscDebugger](https://github.com/ManuelHentschel/vscDebugger).
@@ -31,7 +31,7 @@ For many variables it is also possible to assign a new value to the variable or 
 
 
 ## Installation
-The latest "stable" version of the VS Code extension can be installed from the
+The latest version of the VS Code extension can be installed from the
 [marketplace](https://marketplace.visualstudio.com/items?itemName=RDebugger.r-debugger).
 After installing the extension, the R package can be installed using the command 
 `r.debugger.updateRPackage`.
@@ -51,13 +51,6 @@ or install from the artifacts found
 [here](https://github.com/ManuelHentschel/vscDebugger/actions).
 
 If your R path is neither in the Windows registry nor the `PATH` environment variable, make sure to provide a valid path to the R executable in `r.rpath.xxx`.
-
-**Note on the package version:**
-Since the debugger is still under initial development, both this extension and the accompanying R package are major version 0.y.z.
-The minor version (x.Y.z) is incremented when backward incompatible changes to the interface/communication between the VS Code extension and the R package are introduced.
-Compatibility between the two is only intended ("guaranteed") if both have the same minor version.
-The patch version (x.y.Z) is incremented independently for all other changes that justify a new release.
-
 
 ## Using the Debugger
 ### Launch Mode
@@ -83,7 +76,7 @@ in the callstack labelled 'Global Workspace' to see the variables in `.GlobalEnv
 
 ## Configuration
 For a detailed explanation of possible launch config entries and other settings, see
-[configuration.md](./configuration.md) on github.
+[Configuration](https://manuelhentschel.github.io/vscDebugger/articles/configuration.html).
 
 ## How it works
 The debugger works as follows:
@@ -103,7 +96,7 @@ These lines are also hidden from the user.
 
 
 ## Debugging R Packages
-**New:** Packages can now be debugged using `load_all` from `pkgload`.
+Packages can now be debugged using `load_all` from `pkgload`.
 To do so, it is required to install `pkgload` (part of `devtools`).
 By default, `load_all` will be masked by a modified version that automatically sets breakpoints
 in the loaded package and attaches the modified versions of `print`, `cat`, `message`.
@@ -140,22 +133,8 @@ message <- message
 This assignment can be overwritten by the debugger with
 `.vsc.print`/`.vsc.cat`/`.vsc.message`, but has no effect when not using the debugger.
 
-## Warning
-In the following cases the debugger might not work correctly/as expected:
-
-* Calls to `trace()`, `tracingstate()`:
-These are used to implement breakpoints, so usage might interfere with the debugger's breakpoints
-* Custom `options(error=...)`: the debugger uses its own `options(error=...)` to show stack trace etc. on error
-* Any form of (interactive) user input in the terminal during runtime (e.g. `readline(stdin())`), since
-the debugger passes all user input through `eval(...)`.
-* Code that contains calls to `sys.calls()`, `sys.frames()`, `attr(..., 'srcref')` etc.:
-Since pretty much all code is evaluated through calls to `eval(...)` these results might be wrong. <!-- If required, input in the debug console can be sent directly to R's `stdin` by prepending `###stdin`. -->
-* Extensive use of graphical output/input, stdio-redirecting, `sink()`
-* Extensive use of lazy evaluation, promises, side-effects:
-In the general case, the debugger recognizes unevaluated promises and preserves them.
-It might be possible, however, that the gathering of information about the stack/variables leads to unexpected side-effects.
-Especially watch-expressions must be safe to be evaluated in any frame,
-since these are passed to `eval()` in the currently viewed frame any time the debugger hits a breakpoint or steps through the code.
+## Troubleshooting
+For troubleshooting info, see [Troubleshooting](https://manuelhentschel.github.io/vscDebugger/articles/troubleshooting.html)
 
 ## Contributing
 This package is still under development.


### PR DESCRIPTION
Adds info about timout related settings to troubleshooting vignette (see e.g. https://github.com/ManuelHentschel/VSCode-R-Debugger/issues/138)