### PR TITLE
Use .Last.value

### DIFF
--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -86,7 +86,10 @@ evaluateRequest <- function(response, args, request){
   }
 
   if(!isWatch && session$assignToAns){
-    assign('.ans', valueAndVisible$value, envir = globalenv())
+    ans <- getOption('vsc.ansName', '.Last.value')
+    if(!is.null(ans) && !identical(ans, '')){
+      assign(ans, valueAndVisible$value, envir = globalenv())
+    }
   }
 
   sendResponse(response)


### PR DESCRIPTION
Fix #164 
Use `.Last.value` instead of `.ans` (by default) and make this variable name configurable.
Set to '' to disable.
