### PR TITLE
Fix frame management

### DIFF
--- a/R/debugSource.R
+++ b/R/debugSource.R
@@ -53,7 +53,7 @@
     tmpwd <- setwd(dirname(path))
   }
 
-  registerLaunchFrame(1)
+  registerLaunchFrame(2)
   # actually run the code:
   for(i in seq_along(body0)){
     body <- setAndUpdateBreakpoints(body0, path)

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -162,7 +162,7 @@ evalInEnv <- function(
     )
     unregisterLaunchFrame()
   } else if(catchErrors && showOutput){
-    registerLaunchFrame(8)
+    registerLaunchFrame(7)
     # wrap in try(), withVisible()
     valueAndVisible <- try(
       {

--- a/R/flow.R
+++ b/R/flow.R
@@ -66,6 +66,7 @@ showingPromptRequest <- function(response, args, request){
   } else{
     logPrint('starting paused!!!')
     session$state$startPaused('browser')
+    session$clearStackTree <- TRUE
     sendStoppedEvent(reason='step')
   }
 }

--- a/R/stackTree.R
+++ b/R/stackTree.R
@@ -181,6 +181,7 @@ RootNode <- R6::R6Class(
   public = list(
     getStackNode = function(args=list()) {
       if(lget(args, 'refresh', FALSE) || is.null(private$children$stackNode)){
+        logPrint('Refreshing stack node')
         private$children$stackNode <- StackNode$new(args, self)
       }
       return(private$children$stackNode)


### PR DESCRIPTION
Addresses https://github.com/ManuelHentschel/vscDebugger/issues/163.
Fixes some constants/flags that would not distinguish internal/external frames correctly when using `.vsc.debugSource` and eval requests.