### PR TITLE
Remove svSocket from IMPORTS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,8 +30,7 @@ BugReports:
     https://github.com/ManuelHentschel/vscDebugger/issues
 Imports:
     jsonlite,
-    R6,
-    svSocket
+    R6
 Suggests: 
     pkgload,
     knitr,


### PR DESCRIPTION
Fix https://github.com/ManuelHentschel/VSCode-R-Debugger/issues/140
Substitute for https://github.com/ManuelHentschel/vscDebugger/pull/157, https://github.com/ManuelHentschel/VSCode-R-Debugger/pull/130 

Removes svSocket from imports in DESCRIPTION file.
The package needs a modified version of svSocket anyways, that is meant as a temporary workaround and will hopefully be replaced by a proper socket implementation at some point.