### PR TITLE
Debug Rmd

### DIFF
--- a/man/dot-vsc.debugSource.Rd
+++ b/man/dot-vsc.debugSource.Rd
@@ -11,6 +11,7 @@
   chdir = FALSE,
   print.eval = NULL,
   encoding = "unknown",
+  isRmd = NULL,
   ...
 )
 }


### PR DESCRIPTION
Addresses https://github.com/ManuelHentschel/VSCode-R-Debugger/issues/153.

Modifies the debug source function so that it automatically passes a file through `knitr::purl` if it is rmd. Relies on unmodified line numbers in the output. This seems to work for very "vanilla" rmd files but fails e.g. if the rmd file contains code blocks from other languages. This might be solved by matching parsed lines to actual lines in the source file.