### PR TITLE
Fix promise related C code for R4.6.0

### DIFF
--- a/R/defaultVarInfoHelpers.R
+++ b/R/defaultVarInfoHelpers.R
@@ -151,7 +151,7 @@ getPromiseInfo <- function(name, env) {
 
 #' Test if an object is a promise
 #' 
-#' Starting with R 4.6.0 only strict (non-forced) promises are considered.
+#' Only strict (non-forced) promises are considered.
 #' @param name `character(1L)` the name of the object
 #' @param env [`environment`] the environment of the object 
 #' @return `TRUE` or `FALSE`

--- a/R/defaultVarInfoHelpers.R
+++ b/R/defaultVarInfoHelpers.R
@@ -16,9 +16,8 @@ getVarInEnv <- function(name, env) {
   tryCatch({
     if (name == '...') {
       getDotVars(env)
-    } else if (isPromise(name, env, strict = FALSE)) {
-      prom <- getPromiseVar(name, env)
-      if (isTRUE(prom$evaluated)) prom$value else prom
+    } else if (isPromise(name, env)) {
+      getPromiseVar(name, env)
     } else if (bindingIsActive(name, env) && !getOption('vsc.evaluateActiveBindings', FALSE)) {
       getActiveBinding(name, env)
     } else {
@@ -142,8 +141,6 @@ getPromiseVar <- function(name, env) {
 #' @return A named list: 
 #' * `code`: the expression that will be evaluated
 #' * `environment`: the environment where the promise is evaluated
-#' * `evaluated`: logical flag if the promise has been already evaluated
-#' * `value`: optional node; the value of the evaluated promise
 #' 
 #' @keywords internal
 #' @useDynLib vscDebugger c_promise_info 
@@ -154,17 +151,16 @@ getPromiseInfo <- function(name, env) {
 
 #' Test if an object is a promise
 #' 
+#' Starting with R 4.6.0 only strict (non-forced) promises are considered.
 #' @param name `character(1L)` the name of the object
 #' @param env [`environment`] the environment of the object 
-#' @param strict `logical(1L)` if \code{strict} is \code{TRUE} 
-#'   (the default), evaluated promises return with \code{FALSE}
 #' @return `TRUE` or `FALSE`
 #' 
 #' @keywords internal
 #' @useDynLib vscDebugger c_is_promise
-isPromise <- function(name, env, strict = TRUE) {
+isPromise <- function(name, env) {
   sym <- as.name(name)
-  .Call(c_is_promise, sym, env, strict)
+  .Call(c_is_promise, sym, env)
 }
 
 # Used to deparse object, unless it's too large

--- a/src/promise.c
+++ b/src/promise.c
@@ -63,8 +63,52 @@ SEXP attribute_hidden c_promise_info(SEXP sym, SEXP env) {
 
 #else
 
-// todo:
-// figure out how to do the same as above, using
+// for R >= 4.6.0, use api from:
 // https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Working-with-variable-bindings
+
+SEXP attribute_hidden c_is_promise(SEXP sym, SEXP env) {
+  if (!isSymbol(sym)) {
+    error("'sym' must be a symbol");
+  }
+  if (!isEnvironment(env)) {
+    error("'env' must be an environment");
+  }
+  return ScalarLogical(R_GetBindingType(sym, env) == R_BindingTypeDelayed);
+}
+
+SEXP attribute_hidden c_promise_info(SEXP sym, SEXP env) {
+  if (!isSymbol(sym)) {
+    error("'sym' must be a symbol");
+  }
+  if (!isEnvironment(env)) {
+    error("'env' must be an environment");
+  }
+  if (R_GetBindingType(sym, env) != R_BindingTypeDelayed){
+    error("The object is not a promise");
+  }
+
+  // Get proimse expression and environment
+  SEXP exp = R_DelayedBindingExpression(sym, env);
+  SEXP promise_env = R_DelayedBindingEnvironment(sym, env);
+
+  int len = 2;
+
+  /* allocate and populate list */
+  SEXP ret = PROTECT(allocVector(VECSXP, len));
+  SET_VECTOR_ELT(ret, 0, exp);
+  SET_VECTOR_ELT(ret, 1, promise_env);
+
+  /* create names */
+  SEXP nms = PROTECT(allocVector(STRSXP, len));
+  SET_STRING_ELT(nms, 0, mkChar("code"));
+  SET_STRING_ELT(nms, 1, mkChar("environment"));
+
+  /* assign names to list */
+  setAttrib(ret, R_NamesSymbol, nms);
+
+  /* cleanup and return */
+  UNPROTECT(2);
+  return ret;
+}
 
 #endif

--- a/src/promise.c
+++ b/src/promise.c
@@ -1,5 +1,7 @@
 #include "promise.h"
 
+#if R_VERSION < R_Version(4, 6, 0)
+
 static Rboolean is_promise(SEXP object, Rboolean strict) {
   Rboolean ret = TYPEOF(object) == PROMSXP;
   if (ret && strict) {
@@ -58,3 +60,11 @@ SEXP attribute_hidden c_promise_info(SEXP sym, SEXP env) {
   UNPROTECT(3);
   return ret;
 }
+
+#else
+
+// todo:
+// figure out how to do the same as above, using
+// https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Working-with-variable-bindings
+
+#endif

--- a/src/promise.c
+++ b/src/promise.c
@@ -2,26 +2,19 @@
 
 #if R_VERSION < R_Version(4, 6, 0)
 
-static Rboolean is_promise(SEXP object, Rboolean strict) {
-  Rboolean ret = TYPEOF(object) == PROMSXP;
-  if (ret && strict) {
-    ret = PRVALUE(object) == R_UnboundValue;
-  }
-  return ret;
+static Rboolean is_promise(SEXP object) {
+  return TYPEOF(object) == PROMSXP && PRVALUE(object) == R_UnboundValue;
 }
 
-SEXP attribute_hidden c_is_promise(SEXP sym, SEXP env, SEXP strict) {
+SEXP attribute_hidden c_is_promise(SEXP sym, SEXP env) {
   if (!isSymbol(sym)) {
     error("'sym' must be a symbol");
   }
   if (!isEnvironment(env)) {
     error("'env' must be an environment");
   }
-  if (!IS_SCALAR(strict, LGLSXP)) {
-    error("'strict' must be a boolean");
-  }
   SEXP obj = findVar(sym, env);
-  return ScalarLogical(is_promise(obj, LOGICAL(strict)[0]));
+  return ScalarLogical(is_promise(obj));
 }
 
 SEXP attribute_hidden c_promise_info(SEXP sym, SEXP env) {
@@ -32,26 +25,21 @@ SEXP attribute_hidden c_promise_info(SEXP sym, SEXP env) {
     error("'env' must be an environment");
   }
   SEXP prom = findVar(sym, env);
-  if (!is_promise(prom, FALSE)) {
+  if (!is_promise(prom)) {
     error("The object is not a promise");
   }
-  SEXP val = PROTECT(PRVALUE(prom));
-  Rboolean has_value = (val != R_UnboundValue);
-  int len = has_value ? 4 : 3;
+
+  int len = 2;
 
   /* allocate and populate list */
   SEXP ret = PROTECT(allocVector(VECSXP, len));
   SET_VECTOR_ELT(ret, 0, PRCODE(prom));
   SET_VECTOR_ELT(ret, 1, PRENV(prom));
-  SET_VECTOR_ELT(ret, 2, ScalarLogical(has_value));
-  if (has_value) SET_VECTOR_ELT(ret, 3, val);
 
   /* create names */
   SEXP nms = PROTECT(allocVector(STRSXP, len));
   SET_STRING_ELT(nms, 0, mkChar("code"));
   SET_STRING_ELT(nms, 1, mkChar("environment"));
-  SET_STRING_ELT(nms, 2, mkChar("evaluated"));
-  if (has_value) SET_STRING_ELT(nms, 3, mkChar("value"));
 
   /* assign names to list */
   setAttrib(ret, R_NamesSymbol, nms);

--- a/src/promise.c
+++ b/src/promise.c
@@ -1,58 +1,40 @@
 #include "promise.h"
 
+// Helper functions to get promise info depend on the R version (</>= 4.6.0)
 #if R_VERSION < R_Version(4, 6, 0)
 
-static Rboolean is_promise(SEXP object) {
+static Rboolean is_promise(SEXP sym, SEXP env) {
+  SEXP object = findVar(sym, env);
   return TYPEOF(object) == PROMSXP && PRVALUE(object) == R_UnboundValue;
 }
 
-SEXP attribute_hidden c_is_promise(SEXP sym, SEXP env) {
-  if (!isSymbol(sym)) {
-    error("'sym' must be a symbol");
-  }
-  if (!isEnvironment(env)) {
-    error("'env' must be an environment");
-  }
-  SEXP obj = findVar(sym, env);
-  return ScalarLogical(is_promise(obj));
+static SEXP get_promise_code(SEXP sym, SEXP env) {
+  return PRCODE(findVar(sym, env));
 }
 
-SEXP attribute_hidden c_promise_info(SEXP sym, SEXP env) {
-  if (!isSymbol(sym)) {
-    error("'sym' must be a symbol");
-  }
-  if (!isEnvironment(env)) {
-    error("'env' must be an environment");
-  }
-  SEXP prom = findVar(sym, env);
-  if (!is_promise(prom)) {
-    error("The object is not a promise");
-  }
-
-  int len = 2;
-
-  /* allocate and populate list */
-  SEXP ret = PROTECT(allocVector(VECSXP, len));
-  SET_VECTOR_ELT(ret, 0, PRCODE(prom));
-  SET_VECTOR_ELT(ret, 1, PRENV(prom));
-
-  /* create names */
-  SEXP nms = PROTECT(allocVector(STRSXP, len));
-  SET_STRING_ELT(nms, 0, mkChar("code"));
-  SET_STRING_ELT(nms, 1, mkChar("environment"));
-
-  /* assign names to list */
-  setAttrib(ret, R_NamesSymbol, nms);
-
-  /* cleanup and return */
-  UNPROTECT(3);
-  return ret;
+static SEXP get_promise_environment(SEXP sym, SEXP env) {
+  return PRENV(findVar(sym, env));
 }
 
 #else
 
-// for R >= 4.6.0, use api from:
-// https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Working-with-variable-bindings
+/* for R >= 4.6.0, use API from:
+ * https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Working-with-variable-bindings
+ */
+
+static Rboolean is_promise(SEXP sym, SEXP env) {
+  return R_GetBindingType(sym, env) == R_BindingTypeDelayed;
+}
+
+static SEXP get_promise_code(SEXP sym, SEXP env) {
+  return R_DelayedBindingExpression(sym, env);
+}
+
+static SEXP get_promise_environment(SEXP sym, SEXP env) {
+  return R_DelayedBindingEnvironment(sym, env);
+}
+
+#endif
 
 SEXP attribute_hidden c_is_promise(SEXP sym, SEXP env) {
   if (!isSymbol(sym)) {
@@ -61,7 +43,7 @@ SEXP attribute_hidden c_is_promise(SEXP sym, SEXP env) {
   if (!isEnvironment(env)) {
     error("'env' must be an environment");
   }
-  return ScalarLogical(R_GetBindingType(sym, env) == R_BindingTypeDelayed);
+  return ScalarLogical(is_promise(sym, env));
 }
 
 SEXP attribute_hidden c_promise_info(SEXP sym, SEXP env) {
@@ -71,15 +53,13 @@ SEXP attribute_hidden c_promise_info(SEXP sym, SEXP env) {
   if (!isEnvironment(env)) {
     error("'env' must be an environment");
   }
-  if (R_GetBindingType(sym, env) != R_BindingTypeDelayed){
+  if (!is_promise(sym, env)) {
     error("The object is not a promise");
   }
 
-  // Get proimse expression and environment
-  SEXP exp = R_DelayedBindingExpression(sym, env);
-  SEXP promise_env = R_DelayedBindingEnvironment(sym, env);
-
   int len = 2;
+  SEXP exp = get_promise_code(sym, env);
+  SEXP promise_env = get_promise_environment(sym, env);
 
   /* allocate and populate list */
   SEXP ret = PROTECT(allocVector(VECSXP, len));
@@ -98,5 +78,3 @@ SEXP attribute_hidden c_promise_info(SEXP sym, SEXP env) {
   UNPROTECT(2);
   return ret;
 }
-
-#endif

--- a/src/promise.h
+++ b/src/promise.h
@@ -8,7 +8,13 @@
 #include <R_ext/Error.h>
 #include <Rversion.h>
 
+
+#if R_VERSION < R_Version(4, 6, 0)
 SEXP attribute_hidden c_is_promise(SEXP, SEXP, SEXP);
+#else
+SEXP attribute_hidden c_is_promise(SEXP, SEXP);
+#endif
+
 SEXP attribute_hidden c_promise_info(SEXP, SEXP);
 
 #endif

--- a/src/promise.h
+++ b/src/promise.h
@@ -6,6 +6,7 @@
 #include <Rinternals.h>
 #include <R_ext/Visibility.h>
 #include <R_ext/Error.h>
+#include <Rversion.h>
 
 SEXP attribute_hidden c_is_promise(SEXP, SEXP, SEXP);
 SEXP attribute_hidden c_promise_info(SEXP, SEXP);

--- a/src/promise.h
+++ b/src/promise.h
@@ -9,12 +9,7 @@
 #include <Rversion.h>
 
 
-#if R_VERSION < R_Version(4, 6, 0)
-SEXP attribute_hidden c_is_promise(SEXP, SEXP, SEXP);
-#else
 SEXP attribute_hidden c_is_promise(SEXP, SEXP);
-#endif
-
 SEXP attribute_hidden c_promise_info(SEXP, SEXP);
 
 #endif


### PR DESCRIPTION
Fixes #202

There were some changes to the C-level variable inspection API (see e.g. https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Working-with-variable-bindings), causing compilation to fail with R4.6.0. This PR should fix these issues without any change in behaviour.

